### PR TITLE
Work on following issues #3, #15, #17, #18, #19

### DIFF
--- a/Initialization/StaticWebInitialization.cs
+++ b/Initialization/StaticWebInitialization.cs
@@ -35,6 +35,10 @@ namespace StaticWebEpiserverPlugin.Initialization
                 var contentLink = e.ContentLink;
                 var page = e.Content as PageData;
                 var staticWebService = ServiceLocator.Current.GetInstance<IStaticWebService>();
+                if (!staticWebService.Enabled)
+                {
+                    return;
+                }
 
                 // This page type has a conditional for when we should generate it
                 if (e.Content is IStaticWebIgnoreGenerateDynamically generateDynamically)
@@ -57,6 +61,11 @@ namespace StaticWebEpiserverPlugin.Initialization
             {
                 var block = e.Content as BlockData;
                 var staticWebService = ServiceLocator.Current.GetInstance<IStaticWebService>();
+                if (!staticWebService.Enabled)
+                {
+                    return;
+                }
+
                 staticWebService.GeneratePagesDependingOnBlock(e.ContentLink);
             }
         }

--- a/Models/StaticWebDownloadResult.cs
+++ b/Models/StaticWebDownloadResult.cs
@@ -1,0 +1,9 @@
+﻿namespace StaticWebEpiserverPlugin.Models
+{
+    public class StaticWebDownloadResult
+    {
+        public byte[] Data { get; set; }
+        public string ContentType { get; set; }
+        public string Extension { get; set; }
+    }
+}

--- a/ScheduledJobs/StaticWebScheduledJob.cs
+++ b/ScheduledJobs/StaticWebScheduledJob.cs
@@ -49,6 +49,11 @@ namespace StaticWebEpiserverPlugin.ScheduledJobs
             //Call OnStatusChanged to periodically notify progress of job for manually started jobs
             OnStatusChanged(String.Format("Starting execution of {0}", this.GetType()));
 
+            if (!_staticWebService.Enabled)
+            {
+                return "StaticWeb is not enabled! Add 'StaticWeb:InputUrl' and 'StaticWeb:OutputFolder' under 'appSettings' element in web.config";
+            }
+
             // Setting number of pages to start value (0), it is used to show message after job is done
             _numberOfPages = 0;
             _generatedPages = new Dictionary<int, string>();

--- a/Services/IStaticWebService.cs
+++ b/Services/IStaticWebService.cs
@@ -9,6 +9,11 @@ namespace StaticWebEpiserverPlugin.Services
     public interface IStaticWebService
     {
         /// <summary>
+        /// Shows if service is usable or not.
+        /// Will return false if following settings are not set in web.config 'StaticWeb:OutputFolder' and 'StaticWeb:InputUrl'.
+        /// </summary>
+        bool Enabled { get; }
+        /// <summary>
         /// First thing happening when GeneratePage is called.
         /// StaticWebGeneratePageEventArg is populated with following info: ContentLink, CultureInfo.
         /// Resources can also be populated IF GeneratePage method is called from ScheduledJob and pages generated before had resources depending on them.

--- a/Services/StaticWebService.cs
+++ b/Services/StaticWebService.cs
@@ -489,7 +489,7 @@ namespace StaticWebEpiserverPlugin.Services
                         continue;
                     }
 
-                    var newResourceUrl = EnsureResource(rootUrl, rootPath, resourcePath, resourceUrl);
+                    var newResourceUrl = EnsureResource(rootUrl, rootPath, resourcePath, resourceUrl, replaceResourcePairs);
                     if (!string.IsNullOrEmpty(newResourceUrl))
                     {
                         if (!replaceResourcePairs.ContainsKey(resourceUrl))
@@ -580,7 +580,7 @@ namespace StaticWebEpiserverPlugin.Services
                                 var contentCss = Encoding.UTF8.GetString(data);
                                 string newCssResourceUrl = GetNewResourceUrl(resourcePath, resourceUrl, ".css");
 
-                                EnsureCssResources(rootUrl, rootPath, resourcePath, newCssResourceUrl, contentCss);
+                                EnsureCssResources(rootUrl, rootPath, resourcePath, newCssResourceUrl, contentCss, replaceResourcePairs);
                                 return newCssResourceUrl;
                             case "text/javascript":
                             case "application/javascript":

--- a/StaticWebEpiserverPlugin.csproj
+++ b/StaticWebEpiserverPlugin.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Initialization\StaticWebDisplayModesInitialization.cs" />
     <Compile Include="Interfaces\IStaticWebIgnoreGenerate.cs" />
     <Compile Include="Interfaces\IStaticWebIgnoreGenerateDynamically.cs" />
+    <Compile Include="Models\StaticWebDownloadResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Initialization\StaticWebInitialization.cs" />
     <Compile Include="ScheduledJobs\StaticWebScheduledJob.cs" />


### PR DESCRIPTION
- Now possible to specify sub folder for resources #3
- Resources in CSS files are now added to references resources #15
- We now support both ' and " for resource finding #17
- Possible to disable StaticWebEpiServerPlugin from web.config #18
- Default resource name is now a content hash #3 and #19
- Possible to use old resource naming (by only use resource url for naming) #19
- Possible to use both resource url and content hash for resource naming #3 and #19