### PR TITLE
Some work on issue #49

### DIFF
--- a/App.config
+++ b/App.config
@@ -8,59 +8,59 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.ApplicationModules" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Data.Cache" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Data" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Events" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Framework" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Licensing" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Enterprise" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.LinkAnalyzer" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Framework.AspNet" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Cms.AspNet" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Configuration" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.ImageLibrary" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Web.WebControls" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.20.0.0" newVersion="11.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.20.9.0" newVersion="11.20.9.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.ServiceLocation.StructureMap" publicKeyToken="null" culture="neutral" />
@@ -72,7 +72,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Shell" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.30.0.0" newVersion="11.30.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.36.3.0" newVersion="11.36.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.UI" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
@@ -80,7 +80,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Cms.Shell.UI" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.30.0.0" newVersion="11.30.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.36.3.0" newVersion="11.36.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Events/StaticWebGeneratePageEventArgs.cs
+++ b/Events/StaticWebGeneratePageEventArgs.cs
@@ -1,9 +1,6 @@
-﻿using EPiServer.Core;
-using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 
 namespace StaticWebEpiserverPlugin.Events
 {

--- a/Events/StaticWebIOEvent.cs
+++ b/Events/StaticWebIOEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace StaticWebEpiserverPlugin.Events
+{
+    public class StaticWebIOEvent
+    {
+        public string FilePath { get; set; }
+        public byte[] Data { get; set; }
+    }
+}

--- a/Services/IStaticWebService.cs
+++ b/Services/IStaticWebService.cs
@@ -65,6 +65,9 @@ namespace StaticWebEpiserverPlugin.Services
         /// </summary>
         event EventHandler<StaticWebGeneratePageEventArgs> AfterGeneratePageWrite;
 
+        event EventHandler<StaticWebIOEvent> AfterIOWrite;
+        event EventHandler<StaticWebIOEvent> AfterIODelete;
+
         void GeneratePage(ContentReference contentReference, IContent content, bool? useTemporaryAttribute);
         void GeneratePage(SiteConfigurationElement configuration, PageData page, CultureInfo lang, bool? useTemporaryAttribute, ConcurrentDictionary<string, string> generatedResources = null);
         void GeneratePage(SiteConfigurationElement configuration, string pageUrl, bool? useTemporaryAttribute, string simpleAddress = null, ConcurrentDictionary<string, string> generatedResources = null);

--- a/StaticWebEpiserverPlugin.csproj
+++ b/StaticWebEpiserverPlugin.csproj
@@ -61,65 +61,65 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\EpiServerStaticWebExample\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.Core.11.20.0\lib\net461\EPiServer.dll</HintPath>
+    <Reference Include="EPiServer, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.Core.11.20.9\lib\net461\EPiServer.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.ApplicationModules, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.0\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
+    <Reference Include="EPiServer.ApplicationModules, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.9\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Cms.AspNet, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.AspNet.11.20.0\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Cms.AspNet, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.AspNet.11.20.9\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Cms.Shell.UI, Version=11.30.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.UI.Core.11.30.0\lib\net461\EPiServer.Cms.Shell.UI.dll</HintPath>
+    <Reference Include="EPiServer.Cms.Shell.UI, Version=11.36.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.UI.Core.11.36.3\lib\net461\EPiServer.Cms.Shell.UI.dll</HintPath>
     </Reference>
     <Reference Include="EPiServer.Cms.TinyMce, Version=2.13.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.TinyMce.2.13.0\lib\net461\EPiServer.Cms.TinyMce.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Configuration, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.AspNet.11.20.0\lib\net461\EPiServer.Configuration.dll</HintPath>
+    <Reference Include="EPiServer.Configuration, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.AspNet.11.20.9\lib\net461\EPiServer.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Data, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.0\lib\net461\EPiServer.Data.dll</HintPath>
+    <Reference Include="EPiServer.Data, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.9\lib\net461\EPiServer.Data.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Data.Cache, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.0\lib\net461\EPiServer.Data.Cache.dll</HintPath>
+    <Reference Include="EPiServer.Data.Cache, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.9\lib\net461\EPiServer.Data.Cache.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Enterprise, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.Core.11.20.0\lib\net461\EPiServer.Enterprise.dll</HintPath>
+    <Reference Include="EPiServer.Enterprise, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.Core.11.20.9\lib\net461\EPiServer.Enterprise.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Events, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.0\lib\net461\EPiServer.Events.dll</HintPath>
+    <Reference Include="EPiServer.Events, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.9\lib\net461\EPiServer.Events.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Framework, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.0\lib\net461\EPiServer.Framework.dll</HintPath>
+    <Reference Include="EPiServer.Framework, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.9\lib\net461\EPiServer.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Framework.AspNet, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.AspNet.11.20.0\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Framework.AspNet, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.AspNet.11.20.9\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.ImageLibrary, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.AspNet.11.20.0\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
+    <Reference Include="EPiServer.ImageLibrary, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.AspNet.11.20.9\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Licensing, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.0\lib\net461\EPiServer.Licensing.dll</HintPath>
+    <Reference Include="EPiServer.Licensing, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.Framework.11.20.9\lib\net461\EPiServer.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.LinkAnalyzer, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.Core.11.20.0\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+    <Reference Include="EPiServer.LinkAnalyzer, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.Core.11.20.9\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
     </Reference>
     <Reference Include="EPiServer.ServiceLocation.StructureMap, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\EpiserverAlloyWithForms\packages\EPiServer.ServiceLocation.StructureMap.2.0.3\lib\net461\EPiServer.ServiceLocation.StructureMap.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Shell, Version=11.30.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.UI.Core.11.30.0\lib\net461\EPiServer.Shell.dll</HintPath>
+    <Reference Include="EPiServer.Shell, Version=11.36.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.UI.Core.11.36.3\lib\net461\EPiServer.Shell.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Shell.UI, Version=11.30.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.UI.Core.11.30.0\lib\net461\EPiServer.Shell.UI.dll</HintPath>
+    <Reference Include="EPiServer.Shell.UI, Version=11.36.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.UI.Core.11.36.3\lib\net461\EPiServer.Shell.UI.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.UI, Version=11.30.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.UI.Core.11.30.0\lib\net461\EPiServer.UI.dll</HintPath>
+    <Reference Include="EPiServer.UI, Version=11.36.3.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.UI.Core.11.36.3\lib\net461\EPiServer.UI.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Web.WebControls, Version=11.20.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.AspNet.11.20.0\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
+    <Reference Include="EPiServer.Web.WebControls, Version=11.20.9.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\EPiServer.CMS.AspNet.11.20.9\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\EpiserverAlloyWithForms\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -141,8 +141,8 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.OracleClient" />
-    <Reference Include="System.Data.SqlClient, Version=4.6.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\EpiServerStaticWebExample\packages\System.Data.SqlClient.4.8.1\lib\net461\System.Data.SqlClient.dll</HintPath>
+    <Reference Include="System.Data.SqlClient, Version=4.6.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\EpiServerStaticWebExample\packages\System.Data.SqlClient.4.8.3\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
@@ -207,6 +207,7 @@
     <Compile Include="Configuration\AllowedResourceTypeConfigurationElementCollection.cs" />
     <Compile Include="Configuration\SiteConfigurationElementCollection.cs" />
     <Compile Include="Events\StaticWebGeneratePageEventArgs.cs" />
+    <Compile Include="Events\StaticWebIOEvent.cs" />
     <Compile Include="Initialization\StaticWebDisplayModesInitialization.cs" />
     <Compile Include="Interfaces\IStaticWebIgnoreGenerate.cs" />
     <Compile Include="Interfaces\IStaticWebIgnoreGenerateDynamically.cs" />

--- a/packages.config
+++ b/packages.config
@@ -3,14 +3,14 @@
   <package id="Castle.Core" version="4.4.1" targetFramework="net472" />
   <package id="Castle.Windsor" version="4.1.0" targetFramework="net472" />
   <package id="EntityFramework" version="6.4.4" targetFramework="net472" />
-  <package id="EPiServer.CMS" version="11.20.0" targetFramework="net472" />
-  <package id="EPiServer.CMS.AspNet" version="11.20.0" targetFramework="net472" />
-  <package id="EPiServer.CMS.Core" version="11.20.0" targetFramework="net472" />
+  <package id="EPiServer.CMS" version="11.20.9" targetFramework="net472" />
+  <package id="EPiServer.CMS.AspNet" version="11.20.9" targetFramework="net472" />
+  <package id="EPiServer.CMS.Core" version="11.20.9" targetFramework="net472" />
   <package id="EPiServer.CMS.TinyMce" version="2.13.0" targetFramework="net472" />
-  <package id="EPiServer.CMS.UI" version="11.30.0" targetFramework="net472" />
-  <package id="EPiServer.CMS.UI.Core" version="11.30.0" targetFramework="net472" />
-  <package id="EPiServer.Framework" version="11.20.0" targetFramework="net472" />
-  <package id="EPiServer.Framework.AspNet" version="11.20.0" targetFramework="net472" />
+  <package id="EPiServer.CMS.UI" version="11.36.3" targetFramework="net472" />
+  <package id="EPiServer.CMS.UI.Core" version="11.36.3" targetFramework="net472" />
+  <package id="EPiServer.Framework" version="11.20.9" targetFramework="net472" />
+  <package id="EPiServer.Framework.AspNet" version="11.20.9" targetFramework="net472" />
   <package id="EPiServer.ServiceLocation.StructureMap" version="2.0.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Providers.Core" version="2.0.0" targetFramework="net472" />
@@ -24,7 +24,7 @@
   <package id="structuremap.web-signed" version="3.1.6.191" targetFramework="net472" />
   <package id="structuremap-signed" version="3.1.9.463" targetFramework="net472" />
   <package id="System.ComponentModel.Annotations" version="4.7.0" targetFramework="net472" />
-  <package id="System.Data.SqlClient" version="4.8.1" targetFramework="net472" />
+  <package id="System.Data.SqlClient" version="4.8.3" targetFramework="net472" />
   <package id="System.Reflection.Emit" version="4.7.0" targetFramework="net472" />
   <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net472" />
   <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net472" />


### PR DESCRIPTION
We have now added to new events.
### AfterIOWrite
Is called AFTER a file has been written to disk.
This is usefull to run code after folder has been updated.
For example an azcopy call.

### AfterIODelete
Is called AFTER a file has been written to disk.
This is usefull to run code after folder has been updated.
For example an azcopy call.


### Example use:
![image](https://user-images.githubusercontent.com/62792609/143611928-79dd6e60-e8c1-4b30-8226-3e802e5c824b.png)
